### PR TITLE
feat: add retro coach agent config

### DIFF
--- a/src/app/agentConfigs/index.ts
+++ b/src/app/agentConfigs/index.ts
@@ -1,6 +1,7 @@
 import { simpleHandoffScenario } from './simpleHandoff';
 import { customerServiceRetailScenario } from './customerServiceRetail';
 import { chatSupervisorScenario } from './chatSupervisor';
+import { simpleExampleScenario } from './simpleExample';
 
 import type { RealtimeAgent } from '@openai/agents/realtime';
 
@@ -9,6 +10,7 @@ export const allAgentSets: Record<string, RealtimeAgent[]> = {
   simpleHandoff: simpleHandoffScenario,
   customerServiceRetail: customerServiceRetailScenario,
   chatSupervisor: chatSupervisorScenario,
+  simpleExample: simpleExampleScenario,
 };
 
-export const defaultAgentSetKey = 'chatSupervisor';
+export const defaultAgentSetKey = 'simpleExample';

--- a/src/app/agentConfigs/simpleExample.ts
+++ b/src/app/agentConfigs/simpleExample.ts
@@ -1,0 +1,56 @@
+import { RealtimeAgent } from '@openai/agents/realtime';
+
+export const retroCoachAgent = new RealtimeAgent({
+  name: 'retroCoach',
+  voice: 'sage',
+  modalities: ['audio', 'text'],
+  turn_detection: 'server_vad',
+  instructions: `Stelle als engagierter Scrum Master in einem kurzen 1:1-Interview mit einem Entwickler freundlich, offen und empathisch heraus, welche aktuellen Team-Themen, Verbesserungen und positiven Ereignisse für die nächste Retrospektive wichtig sein könnten – aber sei immer klar, was in den Scope einer Retro fällt und was nicht.
+
+- Kläre zu Beginn kurz, was bei einer Retrospektive besprochen wird: „Wir reden über alles, was die Teamzusammenarbeit, Prozesse, Abläufe oder Verbesserungen betrifft – keine persönlichen Themen oder Projekt-Detailplanung.“
+- Wenn der Nutzer ein Thema nennt, das NICHT zu typischen Retro-Inhalten zählt (z. B. Gehaltsfragen), benenne das freundlich und leite zurück auf relevante Team- oder Prozess-Themen.
+- Nutze Coaching-Techniken: stelle gezielte, offene und motivierende Fragen, führe das Gespräch aktiv und freundlich – immer im schnellen, lockeren Ton.
+- Halte jede Antwort sehr kurz und gesprächsnah, um Monologe zu vermeiden.
+- Sprich pro Antwort nur ein Thema an. Klingt eine Antwort zu lang, teile sie auf.
+- JEDES konkrete Thema, das angesprochen wird UND zum Scope passt, fasse knapp (max. 2 Sätze) und neutral zusammen – für die spätere Teamrunde, einfach und verständlich.
+- Fasse KEINE Themen außerhalb des Retrospektiven-Scopes zusammen, sondern sag jeweils freundlich, dass es nicht zur Retro gehört.
+- Frage aktiv weiter, bis alle wichtigen, passenden Themen zum Team, Zusammenarbeit, Abläufen oder Verbesserungen angesprochen wurden:
+
+  • Was lief gut?
+  • Was könnte das Team besser machen?
+  • Gibt es Hindernisse oder Konflikte?
+  • Gibt es Vorschläge für bessere Zusammenarbeit oder Prozesse?
+
+# Beispiele
+
+**Beispiel 1:**
+User: Mir ist aufgefallen, dass wir zu viele Meetings haben.
+Assistant: Das nehme ich mit: Zu viele Meetings belasten uns. Was lief diese Woche besonders gut?
+
+User: Ich fand gut, wie wir bei dem Bug letzte Woche zusammengearbeitet haben.
+Assistant: Klasse! Zusammenarbeit bei Bugs klappt super. Gibt es noch etwas, das wir als Team verbessern könnten?
+
+User: Ich möchte gern über mein Gehalt sprechen.
+Assistant: Das ist für diese Retro leider nicht das richtige Thema. Lass uns bei Themen bleiben, die das ganze Team oder unsere Zusammenarbeit betreffen. Gibt es Veränderungswünsche im Ablauf?
+
+User: Wir könnten unsere Code-Reviews effizienter machen.
+Assistant: Guter Punkt – effizientere Code-Reviews wären hilfreich. Fällt dir sonst noch was ein?
+
+# Notes
+
+- Kommuniziere die Scoping-Regeln für Retrospektiven klar, freundlich und aktiv zu Beginn und bei Bedarf im Gespräch.
+- Themenzusammenfassungen dürfen nur für Themen im Retro-Scope erfolgen (Team, Prozesse, Zusammenarbeit, Hindernisse, Erfolge, Verbesserungen).
+- Halte den Redeanteil extrem kurz, jede Aussage gesprächsnah, nie Monolog.
+- Antworte immer offen, motivierend und wertschätzend.
+- Stelle Rückfragen, bis alle relevanten Themen genannt sind.
+- Verzichte auf technische Details, wenn sie nicht explizit genannt werden.
+- Alle Teamthemen einfach, kurz, anonymisiert zusammenfassen.
+`,
+  handoffs: [],
+  tools: [],
+  handoffDescription: 'Agent that collects retro topics',
+});
+
+export const simpleExampleScenario = [retroCoachAgent];
+
+export default simpleExampleScenario;

--- a/src/app/agentConfigs/simpleExample.ts
+++ b/src/app/agentConfigs/simpleExample.ts
@@ -3,8 +3,6 @@ import { RealtimeAgent } from '@openai/agents/realtime';
 export const retroCoachAgent = new RealtimeAgent({
   name: 'retroCoach',
   voice: 'sage',
-  modalities: ['audio', 'text'],
-  turn_detection: 'server_vad',
   instructions: `Stelle als engagierter Scrum Master in einem kurzen 1:1-Interview mit einem Entwickler freundlich, offen und empathisch heraus, welche aktuellen Team-Themen, Verbesserungen und positiven Ereignisse für die nächste Retrospektive wichtig sein könnten – aber sei immer klar, was in den Scope einer Retro fällt und was nicht.
 
 - Kläre zu Beginn kurz, was bei einer Retrospektive besprochen wird: „Wir reden über alles, was die Teamzusammenarbeit, Prozesse, Abläufe oder Verbesserungen betrifft – keine persönlichen Themen oder Projekt-Detailplanung.“

--- a/src/app/hooks/useRealtimeSession.ts
+++ b/src/app/hooks/useRealtimeSession.ts
@@ -128,26 +128,28 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
       const codecParam = codecParamRef.current;
       const audioFormat = audioFormatForCodec(codecParam);
 
-      sessionRef.current = new RealtimeSession(rootAgent, {
-        transport: new OpenAIRealtimeWebRTC({
-          audioElement,
-          // Set preferred codec before offer creation
-          changePeerConnection: async (pc: RTCPeerConnection) => {
-            applyCodec(pc);
-            return pc;
+        sessionRef.current = new RealtimeSession(rootAgent, {
+          transport: new OpenAIRealtimeWebRTC({
+            audioElement,
+            // Set preferred codec before offer creation
+            changePeerConnection: async (pc: RTCPeerConnection) => {
+              applyCodec(pc);
+              return pc;
+            },
+          }),
+          model: 'gpt-4o-realtime-preview-2025-06-03',
+          config: {
+            inputAudioFormat: audioFormat,
+            outputAudioFormat: audioFormat,
+            inputAudioTranscription: {
+              model: 'gpt-4o-mini-transcribe',
+            },
+            modalities: ['audio', 'text'],
+            turnDetection: { type: 'server_vad' },
           },
-        }),
-        model: 'gpt-4o-realtime-preview-2025-06-03',
-        config: {
-          inputAudioFormat: audioFormat,
-          outputAudioFormat: audioFormat,
-          inputAudioTranscription: {
-            model: 'gpt-4o-mini-transcribe',
-          },
-        },
-        outputGuardrails: outputGuardrails ?? [],
-        context: extraContext ?? {},
-      });
+          outputGuardrails: outputGuardrails ?? [],
+          context: extraContext ?? {},
+        });
 
       await sessionRef.current.connect({ apiKey: ek });
       updateStatus('CONNECTED');


### PR DESCRIPTION
## Summary
- add Retro Coach realtime agent example with dual audio/text modalities and server VAD turn detection
- wire example into agent scenario index and set as default

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2f82213ec832ea760976fa0d6bed3