### PR TITLE
fix: remove scenario and agent selectors

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -22,8 +22,6 @@ import { createModerationGuardrail } from "@/app/agentConfigs/guardrails";
 
 // Agent configs
 import { allAgentSets, defaultAgentSetKey } from "@/app/agentConfigs";
-import { customerServiceRetailCompanyName } from "@/app/agentConfigs/customerServiceRetail";
-import { chatSupervisorCompanyName } from "@/app/agentConfigs/chatSupervisor";
 
 import useAudioDownload from "./hooks/useAudioDownload";
 import { useHandleSessionHistory } from "./hooks/useHandleSessionHistory";
@@ -190,9 +188,7 @@ function App() {
           reorderedAgents.unshift(agent);
         }
 
-        const companyName = agentSetKey === 'customerServiceRetail'
-          ? customerServiceRetailCompanyName
-          : chatSupervisorCompanyName;
+        const companyName = "Retro Pedro";
         const guardrail = createModerationGuardrail(companyName);
 
         await connect({


### PR DESCRIPTION
## Summary
- remove scenario and agent dropdowns from header
- lock session to default scenario and agent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b36cd1a348832ebf8cde4a1fff7963