### PR TITLE
fix: remove unused search params

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,5 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
-import { useSearchParams } from "next/navigation";
 import { v4 as uuidv4 } from "uuid";
 
 // UI components
@@ -24,8 +23,6 @@ import useAudioDownload from "./hooks/useAudioDownload";
 import { useHandleSessionHistory } from "./hooks/useHandleSessionHistory";
 
 function App() {
-  const searchParams = useSearchParams()!;
-
   // Codec is fixed to Opus; selection UI has been removed.
 
   const {


### PR DESCRIPTION
## Summary
- remove unused `useSearchParams` import and variable from `App.tsx` to satisfy ESLint

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b37132cee4832e8f1c4dbc3c9bc8f7