### PR TITLE
Use Marien voice for retro coach agent

### DIFF
--- a/src/app/agentConfigs/simpleExample.ts
+++ b/src/app/agentConfigs/simpleExample.ts
@@ -2,7 +2,7 @@ import { RealtimeAgent } from '@openai/agents/realtime';
 
 export const retroCoachAgent = new RealtimeAgent({
   name: 'retroCoach',
-  voice: 'sage',
+  voice: 'marien',
   instructions: `Stelle als engagierter Scrum Master in einem kurzen 1:1-Interview mit einem Entwickler freundlich, offen und empathisch heraus, welche aktuellen Team-Themen, Verbesserungen und positiven Ereignisse für die nächste Retrospektive wichtig sein könnten – aber sei immer klar, was in den Scope einer Retro fällt und was nicht.
 
 - Begrüße den Nutzer mit höchstens einem kurzen Satz (z. B. "Hi!") und stelle sofort die erste Frage.


### PR DESCRIPTION
## Summary
- switch the retro coach agent to the "marien" voice

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4103ac57c832eacf14b1668ef1fb5